### PR TITLE
Gather all subscription metrics on a namespace with async

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine as base
+FROM python:3.7-alpine as base
 
 FROM base as buildbase
 
@@ -9,7 +9,7 @@ COPY requirements.txt ./
 
 # Adding build dependencies first, also using cache-dir instead of --no-cache-dir due 
 # to issue https://github.com/pypa/pip/issues/6158#issuecomment-456619072
-RUN apk add --no-cache --virtual .cffi_deps build-base python3-dev libffi-dev openssl-dev && \
+RUN apk add --no-cache --virtual .cffi_deps build-base libffi-dev openssl-dev && \
     pip install --cache-dir=/pipcache --install-option="--prefix=/install" -r requirements.txt && \
     rm -rf /pipcache && \
     apk del .cffi_deps

--- a/config.py
+++ b/config.py
@@ -12,11 +12,13 @@ client_password = os.environ['CLIENT_PASSWORD']
 
 # Service Bus Details
 sb_region = os.environ['SERVICEBUS_REGION']
-sb_resource_id = os.environ['SERVICEBUS_RESOURCE_ID']
 sb_resource_group = os.environ['SERVICEBUS_RESOURCE_GROUP']
 sb_namespace_name = os.environ['SERVICEBUS_NAMESPACE_NAME']
 sb_topic_name = os.environ['SERVICEBUS_TOPIC_NAME']
 sb_subscription_name = os.environ['SERVICEBUS_SUBSCRIPTION_NAME']
+
+# Azure Monitor "Metric Namespace" with customnamespace as default value
+metric_namespace = os.getenv('METRIC_NAMESPACE', 'customnamespace')
 
 # SAS Key
 shared_access_key_name=os.environ['SAS_KEY_NAME']

--- a/mgmt_app.py
+++ b/mgmt_app.py
@@ -1,34 +1,57 @@
+# This uses coroutines available in the asyncio module in Python 3.7+
+# https://docs.python.org/3/library/asyncio-task.html#awaitables
 from azure.common.credentials import ServicePrincipalCredentials
 from azure.mgmt.servicebus import ServiceBusManagementClient
-import os, config, json, monitor_model, datetime, monitor_api
-
-# Parameters for an Azure AD Application that has permission for "Monitoring Metrics Publisher" on the Service Bus Namespace
-credentials = ServicePrincipalCredentials(
-    client_id = config.client_id,
-    secret = config.client_password,
-    tenant = config.tenant_id
-)
+import asyncio, os, config, json, monitor_model, datetime, monitor_api
 
 # Grabbing the time now so we use the same timestamp for all metrics sent to monitor
 query_time = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
 
-servicebus_mgmt_client = ServiceBusManagementClient(credentials, config.subscription_id)
-sb_subscription = servicebus_mgmt_client.subscriptions.get(config.sb_resource_group, config.sb_namespace_name, config.sb_topic_name, config.sb_subscription_name)
-
-#count_details = json.loads(sb_subscription.count_details.text)
-#print (sb_subscription.message_count, sb_subscription.count_details)
-
-def send_to_monitor_api(metric_name, metric_value):
+def send_to_monitor_api(topic_name, subscription_name, metric_name, metric_value):
     # Can't send zero, Monitor will return 400
     if metric_value == 0:
         return
-    series = monitor_model.Series([config.sb_topic_name, config.sb_subscription_name], metric_value, metric_value, metric_value, 1) # Count always 1 since we're sending just one metric value
-    baseData = monitor_model.BaseData(metric_name, "customnamespace", ["TopicName", "SubscriptionName"], [series])
+    series = monitor_model.Series([topic_name, subscription_name], metric_value, metric_value, metric_value, 1) # Count always 1 since we're sending just one metric value
+    baseData = monitor_model.BaseData(metric_name, config.metric_namespace, ["TopicName", "SubscriptionName"], [series])
     data = monitor_model.Data(baseData)
     azureMonitor = monitor_model.AzureMonitor(query_time, data)
-
+    print("Sending", topic_name, subscription_name, metric_name, metric_value)
     monitor_api.send_to_azure_monitor_api(json.dumps(azureMonitor, default=lambda o: o.__dict__))
 
-# Currently only sending active_message_count and dead_letter_message_count
-send_to_monitor_api("active_message_count", sb_subscription.count_details.active_message_count)
-send_to_monitor_api("dead_letter_message_count", sb_subscription.count_details.dead_letter_message_count)
+async def send_subscription_metrics(servicebus_mgmt_client, topic_name):
+    subscriptions = servicebus_mgmt_client.subscriptions.list_by_topic(config.sb_resource_group, config.sb_namespace_name, topic_name)
+    for subscription in subscriptions:
+        send_to_monitor_api(
+            topic_name,
+            subscription.name,
+            "active_message_count",
+            subscription.count_details.active_message_count
+        )
+        send_to_monitor_api(
+            topic_name,
+            subscription.name,
+            "dead_letter_message_count",
+            subscription.count_details.dead_letter_message_count
+        )
+
+async def main():
+    # Parameters for an Azure AD Application that has permission for
+    # "Contributor" and "Monitoring Metrics Publisher" on the Service Bus Namespace
+    credentials = ServicePrincipalCredentials(
+        client_id = config.client_id,
+        secret = config.client_password,
+        tenant = config.tenant_id
+    )
+
+    servicebus_mgmt_client = ServiceBusManagementClient(credentials, config.subscription_id)
+
+    topics = servicebus_mgmt_client.topics.list_by_namespace(config.sb_resource_group, config.sb_namespace_name)
+    # Gather and send metrics for each topic in an async manner.
+    for topic in topics:
+        asyncio.create_task(send_subscription_metrics(servicebus_mgmt_client, topic.name))
+
+
+if __name__ == "__main__":
+    # Run the main func and wait until we're done.
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())

--- a/monitor_api.py
+++ b/monitor_api.py
@@ -51,7 +51,7 @@ def get_azure_token():
         return resp_json["access_token"]
 
 def send_to_azure_monitor_api(postData):
-    apiUrl = f"https://{config.sb_region}.monitoring.azure.com{config.sb_resource_id}/metrics"
+    apiUrl = f"https://{config.sb_region}.monitoring.azure.com/subscriptions/{config.subscription_id}/resourceGroups/{config.sb_resource_group}/providers/Microsoft.ServiceBus/namespaces/{config.sb_namespace_name}/metrics"
     
     token = get_azure_token()
     


### PR DESCRIPTION
- Gather all subscriptions to all topics on a given Service Bus namespace in an async fashion and send them all to Azure Monitor.
Uses Python 3.7's coroutines with async: https://docs.python.org/3/library/asyncio-task.html
- Computes the Azure resource id of a Service Bus Namespace from the Subscription ID, Resource Group, and Namespace name, reducing the variables required to run.

